### PR TITLE
Add device tree API endpoints.

### DIFF
--- a/src/backend/controllers/device.js
+++ b/src/backend/controllers/device.js
@@ -1,0 +1,161 @@
+import Router from '@koa/router';
+import moment from 'moment';
+import Joi from '@hapi/joi';
+import { getLogger } from '../log.js';
+import { BadRequestError } from '../../common/errors.js';
+
+const log = getLogger('backend:controllers:device');
+
+const query_schema = Joi.object({
+  start: Joi.number()
+    .integer()
+    .greater(-1),
+  end: Joi.number()
+    .integer()
+    .positive(),
+  asc: Joi.boolean(),
+  sort_by: Joi.string(),
+  from: Joi.string(),
+  to: Joi.string(),
+  author: Joi.number().integer(),
+  library: Joi.number().integer(),
+});
+
+async function validate_query(query) {
+  try {
+    const value = await query_schema.validateAsync(query);
+    return value;
+  } catch (err) {
+    throw new BadRequestError('Unable to validate query: ', err);
+  }
+}
+
+// eslint-disable-next-line no-unused-vars
+export default function controller(devices, thisUser) {
+  const router = new Router();
+
+  router.post('/devices', async ctx => {
+    log.debug('Adding new device.');
+    let device;
+    try {
+      device = await devices.create(ctx.request.body);
+
+      // workaround for sqlite
+      if (Number.isInteger(device)) {
+        device = await devices.findById(device);
+      }
+    } catch (err) {
+      ctx.throw(400, `Failed to parse device schema: ${err}`);
+    }
+    ctx.response.body = { status: 'success', data: device };
+    ctx.response.status = 201;
+  });
+
+  router.get('/devices', async ctx => {
+    log.debug(`Retrieving devices.`);
+    let res;
+    try {
+      const query = await validate_query(ctx.query);
+      let from, to;
+      if (query.from) {
+        const timestamp = moment(query.from);
+        if (timestamp.isValid()) {
+          ctx.throw(400, 'Invalid timestamp value.');
+        }
+        from = timestamp.toISOString();
+      }
+      if (query.to) {
+        const timestamp = moment(query.to);
+        if (timestamp.isValid()) {
+          ctx.throw(400, 'Invalid timestamp value.');
+        }
+        to = timestamp.toISOString();
+      }
+      res = await devices.find({
+        start: query.start,
+        end: query.end,
+        asc: query.asc,
+        sort_by: query.sort_by,
+        from: from,
+        to: to,
+        library: query.library,
+      });
+      ctx.response.body = {
+        status: 'success',
+        data: res,
+        total: res.length,
+      };
+      ctx.response.status = 200;
+    } catch (err) {
+      ctx.throw(400, `Failed to parse query: ${err}`);
+    }
+  });
+
+  router.get('/devices/:id', async ctx => {
+    log.debug(`Retrieving device ${ctx.params.id}.`);
+    let device;
+    try {
+      device = await devices.findById(ctx.params.id);
+      if (device.length) {
+        ctx.response.body = { status: 'success', data: device };
+        ctx.response.status = 200;
+      } else {
+        ctx.response.body = {
+          status: 'error',
+          message: `That device with ID ${ctx.params.id} does not exist.`,
+        };
+        ctx.response.status = 404;
+      }
+    } catch (err) {
+      ctx.throw(400, `Failed to parse query: ${err}`);
+    }
+  });
+
+  router.put('/devices/:id', async ctx => {
+    log.debug(`Updating device ${ctx.params.id}.`);
+    let device;
+    try {
+      device = await devices.update(ctx.params.id, ctx.request.body);
+
+      // workaround for sqlite
+      if (Number.isInteger(device)) {
+        device = await devices.findById(device);
+      }
+
+      if (device.length) {
+        ctx.response.body = { status: 'success', data: device };
+        ctx.response.status = 200;
+      } else {
+        ctx.response.body = {
+          status: 'error',
+          message: `That device with ID ${ctx.params.id} does not exist.`,
+        };
+        ctx.response.status = 404;
+      }
+    } catch (err) {
+      ctx.throw(400, `Failed to parse query: ${err}`);
+    }
+  });
+
+  router.delete('/devices/:id', async ctx => {
+    log.debug(`Deleting device ${ctx.params.id}.`);
+    let device;
+    try {
+      device = await devices.delete(ctx.params.id);
+      if (device.length) {
+        ctx.response.body = { status: 'success', data: device };
+        ctx.response.status = 200;
+      } else {
+        ctx.response.body = {
+          status: 'error',
+          message: `That device with ID ${ctx.params.id} does not exist.`,
+        };
+        ctx.response.status = 404;
+      }
+    } catch (err) {
+      ctx.throw(400, `Failed to parse query: ${err}`);
+    }
+  });
+
+  return router;
+}

--- a/src/backend/db/migrations/common/20200503204320_create_devices.js
+++ b/src/backend/db/migrations/common/20200503204320_create_devices.js
@@ -1,0 +1,43 @@
+import { onUpdateTrigger } from '../../../utils/updateTimestamp.js';
+
+export function up(knex) {
+  return Promise.all([
+    knex.schema
+      .createTable('devices', table => {
+        table
+          .increments('id')
+          .primary()
+          .unsigned();
+        table.string('name');
+        table.string('network_type');
+        table.string('connection_type');
+        table.string('dns_server');
+        table.string('ip');
+        table.string('gateway');
+        table.string('mac');
+        table.timestamps(true, true);
+      })
+      .then(() =>
+        knex.raw(onUpdateTrigger(knex.context.client.config.client, 'devices')),
+      ),
+    knex.schema.createTable('library_devices', table => {
+      table.integer('lid').index();
+      table
+        .foreign('lid')
+        .references('id')
+        .inTable('libraries');
+      table.integer('did').index();
+      table
+        .foreign('did')
+        .references('id')
+        .inTable('devices');
+    }),
+  ]);
+}
+
+export function down(knex) {
+  return Promise.all([
+    knex.schema.dropTable('library_devices'),
+    knex.schema.dropTable('devices'),
+  ]);
+}

--- a/src/backend/db/seeds/development/devices.js
+++ b/src/backend/db/seeds/development/devices.js
@@ -1,5 +1,5 @@
 export function seed(knex) {
-  return knex('notes')
+  return knex('devices')
     .del()
     .then(function() {
       // Inserts seed entries

--- a/src/backend/db/seeds/development/devices.js
+++ b/src/backend/db/seeds/development/devices.js
@@ -1,0 +1,55 @@
+export function seed(knex) {
+  return knex('notes')
+    .del()
+    .then(function() {
+      // Inserts seed entries
+      return Promise.all([
+        knex('devices').insert([
+          {
+            id: 1,
+            name: 'murakami0',
+            network_type: 'private',
+            connection_type: 'wired',
+            dns_server: '192.168.1.1',
+            ip: '192.168.1.41',
+            gateway: '192.168.1.1',
+            mac: 'ab:bc:cd:de:ef:01',
+          },
+          {
+            id: 2,
+            name: 'murakami1',
+            network_type: 'public',
+            connection_type: 'wireless',
+            dns_server: '192.168.1.1',
+            ip: '192.168.1.42',
+            gateway: '192.168.1.1',
+            mac: 'ab:bc:cd:de:ef:02',
+          },
+          {
+            id: 3,
+            name: 'murakami2',
+            network_type: 'public',
+            connection_type: 'wireless',
+            dns_server: '192.168.1.1',
+            ip: '192.168.1.43',
+            gateway: '192.168.1.1',
+            mac: 'ab:bc:cd:de:ef:03',
+          },
+        ]),
+        knex('library_devices').insert([
+          {
+            lid: 1,
+            did: 1,
+          },
+          {
+            lid: 1,
+            did: 2,
+          },
+          {
+            lid: 1,
+            did: 3,
+          },
+        ]),
+      ]);
+    });
+}

--- a/src/backend/db/seeds/development/libraries.js
+++ b/src/backend/db/seeds/development/libraries.js
@@ -1,5 +1,5 @@
 export function seed(knex) {
-  return knex('notes')
+  return knex('libraries')
     .del()
     .then(function() {
       // Inserts seed entries

--- a/src/backend/db/seeds/test/devices.js
+++ b/src/backend/db/seeds/test/devices.js
@@ -1,5 +1,5 @@
 export function seed(knex) {
-  return knex('notes')
+  return knex('devices')
     .del()
     .then(function() {
       // Inserts seed entries

--- a/src/backend/db/seeds/test/devices.js
+++ b/src/backend/db/seeds/test/devices.js
@@ -1,0 +1,55 @@
+export function seed(knex) {
+  return knex('notes')
+    .del()
+    .then(function() {
+      // Inserts seed entries
+      return Promise.all([
+        knex('devices').insert([
+          {
+            id: 1,
+            name: 'murakami0',
+            network_type: 'private',
+            connection_type: 'wired',
+            dns_server: '192.168.1.1',
+            ip: '192.168.1.41',
+            gateway: '192.168.1.1',
+            mac: 'ab:bc:cd:de:ef:01',
+          },
+          {
+            id: 2,
+            name: 'murakami1',
+            network_type: 'public',
+            connection_type: 'wireless',
+            dns_server: '192.168.1.1',
+            ip: '192.168.1.42',
+            gateway: '192.168.1.1',
+            mac: 'ab:bc:cd:de:ef:02',
+          },
+          {
+            id: 3,
+            name: 'murakami2',
+            network_type: 'public',
+            connection_type: 'wireless',
+            dns_server: '192.168.1.1',
+            ip: '192.168.1.43',
+            gateway: '192.168.1.1',
+            mac: 'ab:bc:cd:de:ef:03',
+          },
+        ]),
+        knex('library_devices').insert([
+          {
+            lid: 1,
+            did: 1,
+          },
+          {
+            lid: 1,
+            did: 2,
+          },
+          {
+            lid: 1,
+            did: 3,
+          },
+        ]),
+      ]);
+    });
+}

--- a/src/backend/db/seeds/test/libraries.js
+++ b/src/backend/db/seeds/test/libraries.js
@@ -1,5 +1,5 @@
 export function seed(knex) {
-  return knex('notes')
+  return knex('libraries')
     .del()
     .then(function() {
       // Inserts seed entries

--- a/src/backend/db/seeds/test/libraries.js
+++ b/src/backend/db/seeds/test/libraries.js
@@ -1,0 +1,37 @@
+export function seed(knex) {
+  return knex('notes')
+    .del()
+    .then(function() {
+      // Inserts seed entries
+      return knex('libraries').insert([
+        {
+          id: 1,
+          name: 'MLK Library',
+          physical_address: '901 G St. NW, Washington, DC 20001',
+          shipping_address: '901 G St. NW, Washington, DC 20001',
+          timezone: 'utc',
+          coordinates: '-77.0366, 38.895',
+          primary_contact_name: 'Jane Doe',
+          primary_contact_email: 'jane@protonmail.com',
+          it_contact_name: 'James Brown',
+          it_contact_email: 'james@protonmail.com',
+          opening_hours: 'M-F, 9:00 AM - 5:00 PM',
+          network_name: 'Public Access',
+          isp: 'Comcast',
+          contracted_speed_upload: '40 Mbit/s',
+          contracted_speed_download: '100 Mbit/s',
+          ip: '0.0.0.0',
+          bandwith_cap_upload: '40 Mbit/s',
+          bandwith_cap_download: '100 Mbit/s',
+          device_name: 'Lorem ipsum',
+          device_location: 'Lorem ipsum',
+          device_network_type: 'public',
+          device_connection_type: 'wired',
+          device_dns: '8.8.8.8',
+          device_ip: '1.1.1.1',
+          device_gateway: 'Lorem ipsum',
+          device_mac_address: 'Lorem ipsum',
+        },
+      ]);
+    });
+}

--- a/src/backend/models/device.js
+++ b/src/backend/models/device.js
@@ -1,0 +1,108 @@
+import knex from 'knex';
+import { validate } from '../../common/schemas/device.js';
+import { UnprocessableError } from '../../common/errors.js';
+
+export default class DeviceManager {
+  constructor(db) {
+    this._db = db;
+  }
+
+  async create(device) {
+    try {
+      await validate(device);
+    } catch (err) {
+      throw new UnprocessableError('Failed to create device: ', err);
+    }
+    return this._db
+      .table('devices')
+      .insert(device)
+      .returning('*');
+  }
+
+  async update(id, device) {
+    try {
+      await validate(device);
+    } catch (err) {
+      throw new UnprocessableError('Failed to update device: ', err);
+    }
+    return this._db
+      .table('devices')
+      .update(device)
+      .where({ id: parseInt(id) })
+      .update(
+        {
+          subject: device.subject,
+          description: device.description,
+          updated_at: device.updated_at,
+        },
+        ['id', 'subject', 'description', 'updated_at'],
+      )
+      .returning('*');
+  }
+
+  async delete(id) {
+    return this._db
+      .table('devices')
+      .del()
+      .where({ id: parseInt(id) })
+      .returning('*');
+  }
+
+  async find({
+    start: start = 0,
+    end: end,
+    asc: asc = true,
+    sort_by: sort_by = 'id',
+    from: from,
+    to: to,
+    library: library,
+  }) {
+    const rows = await this._db
+      .table('devices')
+      .select('*')
+      .modify(queryBuilder => {
+        if (from) {
+          queryBuilder.where('created_at', '>', from);
+        }
+
+        if (to) {
+          queryBuilder.where('created_at', '<', to);
+        }
+
+        if (library) {
+          queryBuilder.join(
+            'library_devices',
+            'library_devices.lid',
+            knex.raw('?', [library]),
+          );
+        }
+
+        if (asc) {
+          queryBuilder.orderBy(sort_by, 'asc');
+        } else {
+          queryBuilder.orderBy(sort_by, 'desc');
+        }
+
+        if (start > 0) {
+          queryBuilder.offset(start);
+        }
+
+        if (end && end > start) {
+          queryBuilder.limit(end - start);
+        }
+      });
+
+    return rows || [];
+  }
+
+  async findById(id) {
+    return this._db
+      .table('devices')
+      .select('*')
+      .where({ id: parseInt(id) });
+  }
+
+  async findAll() {
+    return this._db.table('devices').select('*');
+  }
+}

--- a/src/backend/server.js
+++ b/src/backend/server.js
@@ -18,10 +18,12 @@ import cloudflareAccess from './middleware/cloudflare.js';
 import UserController from './controllers/user.js';
 import GroupController from './controllers/group.js';
 import LibraryController from './controllers/library.js';
+import DeviceController from './controllers/device.js';
 import NoteController from './controllers/note.js';
 import RunController from './controllers/run.js';
 import SystemController from './controllers/system.js';
 import Libraries from './models/library.js';
+import Devices from './models/device.js';
 import Notes from './models/note.js';
 import Runs from './models/run.js';
 import Systems from './models/system.js';
@@ -58,6 +60,8 @@ export default function configServer(config) {
   const groups = GroupController(groupModel, auth);
   const libraryModel = new Libraries(db);
   const libraries = LibraryController(libraryModel, auth);
+  const deviceModel = new Devices(db);
+  const devices = DeviceController(deviceModel, auth);
   const noteModel = new Notes(db);
   const notes = NoteController(noteModel, auth);
   const runModel = new Runs(db);
@@ -71,6 +75,8 @@ export default function configServer(config) {
     groups.allowedMethods(),
     libraries.routes(),
     libraries.allowedMethods(),
+    devices.routes(),
+    devices.allowedMethods(),
     notes.routes(),
     notes.allowedMethods(),
     runs.routes(),

--- a/src/common/schemas/device.js
+++ b/src/common/schemas/device.js
@@ -1,0 +1,26 @@
+import { UnprocessableError } from '../../common/errors.js';
+import Joi from '@hapi/joi';
+
+const schema = Joi.object({
+  id: Joi.number(),
+  name: Joi.string(),
+  network_type: Joi.string(),
+  connection_type: Joi.string(),
+  dns_server: Joi.string().ip(),
+  ip: Joi.string().ip(),
+  gateway: Joi.string().ip(),
+  mac: Joi.string().pattern(
+    /^[0-9a-f]{1,2}([.:-])[0-9a-f]{1,2}(?:\1[0-9a-f]{1,2}){4}$/,
+  ),
+  created_at: Joi.string(),
+  updated_at: Joi.string(),
+});
+
+export async function validate(data) {
+  try {
+    const value = await schema.validateAsync(data);
+    return value;
+  } catch (err) {
+    throw new UnprocessableError('Unable to validate test JSON: ', err);
+  }
+}


### PR DESCRIPTION
This adds the backend API endpoints for retrieving and managing devices. It doesn't include frontend components, so must be tested with `curl` or similar. Resolves #5 