### PR TITLE
Fix date handling on Firefox for notes, and remove duplicates from notes page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1128,6 +1128,21 @@
         "@date-io/core": "^1.3.13"
       }
     },
+    "@date-io/moment": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@date-io/moment/-/moment-2.6.0.tgz",
+      "integrity": "sha512-G2gpe2AEW221lJGNPjy6ImnJuwFWLwkpJ/IfU3EFbblo/tCzyDmREh7spdDW8auqm5a9EOZShcCIpsommf6L0w==",
+      "requires": {
+        "@date-io/core": "^2.6.0"
+      },
+      "dependencies": {
+        "@date-io/core": {
+          "version": "2.6.0",
+          "resolved": "https://registry.npmjs.org/@date-io/core/-/core-2.6.0.tgz",
+          "integrity": "sha512-GkM3jTlh9r3MfZEuFKV4g1JSbxz1G0Or1CBKkhPcw7UCJRjjsk5mLVYZYtUQEsOY8rCSFUTdCOm63ulWzAC/pw=="
+        }
+      }
+    },
     "@datepicker-react/hooks": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/@datepicker-react/hooks/-/hooks-2.3.1.tgz",

--- a/package.json
+++ b/package.json
@@ -98,6 +98,7 @@
   },
   "dependencies": {
     "@date-io/date-fns": "^1.3.13",
+    "@date-io/moment": "^2.6.0",
     "@datepicker-react/hooks": "^2.3.1",
     "@hapi/joi": "^17.1.1",
     "@koa/cors": "2.2.3",

--- a/src/backend/models/note.js
+++ b/src/backend/models/note.js
@@ -90,11 +90,10 @@ export default class NoteManager {
         }
 
         if (library) {
-          queryBuilder.join(
-            'library_notes',
-            'library_notes.lid',
-            knex.raw('?', [library]),
-          );
+          queryBuilder.join('library_notes', {
+            'notes.id': 'library_notes.nid',
+            'library_notes.lid': knex.raw('?', [library]),
+          });
         }
 
         if (asc) {

--- a/src/frontend/components/dashboard/Home.jsx
+++ b/src/frontend/components/dashboard/Home.jsx
@@ -153,8 +153,10 @@ export default function Home(props) {
 
   // handle glossary terms
   const handleGlossary = term => {
-    return (glossary.find(word => word.term.toLowerCase() === term.toLowerCase()));
-  }
+    return glossary.find(
+      word => word.term.toLowerCase() === term.toLowerCase(),
+    );
+  };
 
   // handle date range
   const today = new Date();
@@ -226,7 +228,7 @@ export default function Home(props) {
   React.useEffect(() => {
     let status, glossaryStatus;
 
-    if ( library ) {
+    if (library) {
       fetch(`/api/v1/libraries/${library.id}/runs`)
         .then(res => {
           status = res.status;
@@ -267,17 +269,16 @@ export default function Home(props) {
         console.error(error.name + error.message);
         setIsLoaded(true);
       });
+  }, [library]);
 
-  }, [ library ]);
-
-  if ( error ) {
+  if (error) {
     return <div>Error: {error.message}</div>;
-  } else if ( !isLoaded ) {
+  } else if (!isLoaded) {
     return <Loading />;
-  } else if ( !library ) {
+  } else if (!library) {
     return (
       <Suspense>
-        <Box mb={9} >
+        <Box mb={9}>
           <Typography component="h1" variant="h3">
             MLBN Data Visualization
           </Typography>
@@ -314,7 +315,7 @@ export default function Home(props) {
                 >
                   Add a note
                 </Button>
-                <AddNote open={open} onClose={handleClose} />
+                <AddNote open={open} onClose={handleClose} library={library} />
               </Grid>
             </Grid>
             <Grid container item spacing={1} xs={6}>
@@ -468,12 +469,7 @@ export default function Home(props) {
             </Grid>
           </Box>
           <Grid container justify="space-between" alignItems="center">
-            <Grid
-              container
-              alignItems="center"
-              item
-              spacing={2}
-            >
+            <Grid container alignItems="center" item spacing={2}>
               <Grid item>
                 <Typography variant="overline" display="block" gutterBottom>
                   Group by
@@ -499,7 +495,7 @@ export default function Home(props) {
             </Grid>
             <Grid item xs={12} sm={2}>
               <Button variant="contained">
-                <CSVLink data={runs ? runs : '' } headers={headers}>
+                <CSVLink data={runs ? runs : ''} headers={headers}>
                   Export
                 </CSVLink>
               </Button>

--- a/src/frontend/components/dashboard/Notes.jsx
+++ b/src/frontend/components/dashboard/Notes.jsx
@@ -2,7 +2,7 @@
 import React, { Suspense } from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';
-import { lighten, makeStyles, useTheme } from '@material-ui/core/styles';
+import { lighten, makeStyles } from '@material-ui/core/styles';
 import Moment from 'react-moment';
 import Truncate from 'react-truncate';
 
@@ -20,11 +20,9 @@ import TableRow from '@material-ui/core/TableRow';
 import TableSortLabel from '@material-ui/core/TableSortLabel';
 import Toolbar from '@material-ui/core/Toolbar';
 import Typography from '@material-ui/core/Typography';
-import FormControlLabel from '@material-ui/core/FormControlLabel';
 
 // modules imports
 import AddNote from '../utils/AddNote.jsx';
-import EditNote from '../utils/EditNote.jsx';
 import Loading from '../Loading.jsx';
 import ViewNote from '../utils/ViewNote.jsx';
 
@@ -259,7 +257,7 @@ export default function EnhancedTable(props) {
   React.useEffect(() => {
     let status;
 
-    if ( library ) {
+    if (library) {
       fetch(`/api/v1/libraries/${library.id}/notes`)
         .then(res => {
           status = res.status;
@@ -286,17 +284,16 @@ export default function EnhancedTable(props) {
     } else {
       setIsLoaded(true);
     }
-
   }, []);
 
-  if ( error ) {
+  if (error) {
     return <div>Error: {error.message}</div>;
-  } else if ( !isLoaded ) {
+  } else if (!isLoaded) {
     return <Loading />;
-  } else if ( !library ) {
+  } else if (!library) {
     return (
       <Suspense>
-        <Box mb={9} >
+        <Box mb={9}>
           <Typography component="p" variant="body1">
             No notes to display.
           </Typography>
@@ -343,7 +340,7 @@ export default function EnhancedTable(props) {
                             padding="none"
                           >
                             <Moment
-                              date={row.updated_at}
+                              date={row.date}
                               format="MMMM D, YYYY, h:mma"
                             />
                           </TableCell>

--- a/src/frontend/components/utils/AddNote.jsx
+++ b/src/frontend/components/utils/AddNote.jsx
@@ -129,7 +129,7 @@ export default function AddNote(props) {
           <DateTimePicker
             className={classes.datePicker}
             value={date}
-            onChange={e => setDate(e.target.value)}
+            onChange={e => setDate(e)}
           />
         </MuiPickersUtilsProvider>
 

--- a/src/frontend/components/utils/AddNote.jsx
+++ b/src/frontend/components/utils/AddNote.jsx
@@ -1,7 +1,8 @@
 // base imports
-import React, { useState } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import { makeStyles } from '@material-ui/core/styles';
+import DateFnUtils from '@date-io/date-fns';
 
 // material ui imports
 import Box from '@material-ui/core/Box';
@@ -10,6 +11,7 @@ import Dialog from '@material-ui/core/Dialog';
 import DialogTitle from '@material-ui/core/DialogTitle';
 import Grid from '@material-ui/core/Grid';
 import TextField from '@material-ui/core/TextField';
+import { MuiPickersUtilsProvider, DateTimePicker } from '@material-ui/pickers';
 
 // icons imports
 import ClearIcon from '@material-ui/icons/Clear';
@@ -38,40 +40,20 @@ const useStyles = makeStyles(() => ({
   formField: {
     marginBottom: '30px',
   },
+  datePicker: {
+    marginBottom: '30px',
+  },
   saveButton: {
     marginBottom: '0',
   },
 }));
 
-function formatDate(date) {
-  return date.toISOString().substring(0, 19);
-}
-
-const useForm = callback => {
-  const [inputs, setInputs] = useState({});
-  const handleSubmit = event => {
-    if (event) {
-      event.preventDefault();
-    }
-    callback();
-  };
-  const handleInputChange = event => {
-    event.persist();
-    setInputs(inputs => ({
-      ...inputs,
-      [event.target.name]: event.target.value,
-    }));
-  };
-  return {
-    handleSubmit,
-    handleInputChange,
-    inputs,
-  };
-};
-
 export default function AddNote(props) {
   const classes = useStyles();
   const { onClose, open, library } = props;
+  const [date, setDate] = React.useState(new Date());
+  const [description, setDescription] = React.useState();
+  const [subject, setSubject] = React.useState();
 
   const handleClose = () => {
     onClose();
@@ -85,7 +67,9 @@ export default function AddNote(props) {
       headers: {
         'Content-Type': 'application/json',
       },
-      body: JSON.stringify({ data: inputs }),
+      body: JSON.stringify({
+        data: { subject: subject, date: date, description: description },
+      }),
     })
       .then(res => {
         status = res.status;
@@ -94,7 +78,7 @@ export default function AddNote(props) {
       .then(() => {
         if (status === 201) {
           alert('Note submitted successfully.');
-          onClose(inputs);
+          onClose({ subject: subject, date: date, description: description });
           return;
         } else {
           throw new Error(`Error in response from server.`);
@@ -108,8 +92,6 @@ export default function AddNote(props) {
         onClose();
       });
   };
-
-  const { inputs, handleInputChange, handleSubmit } = useForm(submitData);
 
   return (
     <Dialog
@@ -140,22 +122,17 @@ export default function AddNote(props) {
           name="subject"
           fullWidth
           variant="outlined"
-          onChange={handleInputChange}
+          onChange={e => setSubject(e.target.value)}
         />
-        <div className={classes.formField}>
-          <TextField
-            id="note-datetime"
-            label="Date"
-            name="updated_at"
-            type="datetime-local"
-            className={classes.textField}
-            defaultValue={formatDate(new Date())}
-            onChange={handleInputChange}
-            InputLabelProps={{
-              shrink: true,
-            }}
+
+        <MuiPickersUtilsProvider utils={DateFnUtils}>
+          <DateTimePicker
+            className={classes.datePicker}
+            value={date}
+            onChange={e => setDate(e.target.value)}
           />
-        </div>
+        </MuiPickersUtilsProvider>
+
         <TextField
           className={classes.formField}
           id="note-description"
@@ -165,7 +142,7 @@ export default function AddNote(props) {
           rows="5"
           fullWidth
           variant="outlined"
-          onChange={handleInputChange}
+          onChange={e => setDescription(e.target.value)}
         />
         <Grid container alignItems="center" justify="space-between">
           <Grid item>
@@ -188,7 +165,7 @@ export default function AddNote(props) {
               disableElevation
               color="primary"
               primary={true}
-              onClick={handleSubmit}
+              onClick={submitData}
             >
               Save
             </Button>

--- a/src/frontend/components/utils/EditNote.jsx
+++ b/src/frontend/components/utils/EditNote.jsx
@@ -121,7 +121,7 @@ export default function EditNote(props) {
           <DateTimePicker
             className={classes.datePicker}
             value={date}
-            onChange={e => setDate(e.target.value)}
+            onChange={e => setDate(e)}
           />
         </MuiPickersUtilsProvider>
 


### PR DESCRIPTION
This replaces the standard material-ui date picker that doesn't render on Firefox with @material-ui/pickers, changes the notes page to use the `date` field instead of `updated_at`, and removes duplicates entries from the notes list. Fixes #29 